### PR TITLE
Fix delete last cell + reorganize db_to_df

### DIFF
--- a/scripts/demo_neuromast.py
+++ b/scripts/demo_neuromast.py
@@ -35,6 +35,7 @@ working_directory = Path(
 # working_directory = Path("/Users/teun.huijben/Documents/data/Akila/20241003_neuromast4/adjusted/")
 # working_directory = Path("/hpc/projects/jacobo_group/iSim_processed_files/steady_state_timelapses/20241003_2dpf_myo6b_bactin_GFP_she_h2b_gfp_cldnb_lyn_mScarlet/46hpf_fish1_1/4_tracking/database/")
 # path to the working directory that contains the database file AND metadata.toml
+
 db_filename_old = "data.db"  # name of the database file to start from
 Tmax = 600  # maximum number of frames display (crop the data to this number of frames)
 scale = (2.31, 1, 1)  # (Z),Y,X

--- a/trackedit/DatabaseHandler.py
+++ b/trackedit/DatabaseHandler.py
@@ -117,6 +117,7 @@ class DatabaseHandler:
                 time_window=self.time_window,
             )
         self.df_full = self.db_to_df(entire_database=True)
+        #ToDo: df_full might be very large for large datasets, but annotation/redflags/division need it
         self.nxgraph = self.df_to_nxgraph()
         self.red_flags = self.find_all_red_flags()
         self.toannotate = self.find_all_toannotate()

--- a/trackedit/TrackEditClass.py
+++ b/trackedit/TrackEditClass.py
@@ -93,7 +93,7 @@ class TrackEditClass:
         self.NavigationWidget.red_flag_box.update_chunk_from_frame_signal.connect(
             self.update_chunk_from_frame
         )
-        self.AnnotationWidget.todo_box.update_chunk_from_frame_signal.connect(
+        self.AnnotationWidget.toannotate_box.update_chunk_from_frame_signal.connect(
             self.update_chunk_from_frame
         )
         self.EditingMenu.add_cell_button_pressed.connect(self.add_cell_from_database)

--- a/trackedit/motile_overwrites.py
+++ b/trackedit/motile_overwrites.py
@@ -72,6 +72,7 @@ def create_db_delete_nodes(DB_handler):
             DB_handler.change_values(
                 indices=orphaned_children, field=NodeDB.parent_id, values=-1
             )
+            #ToDo: potentially only remove orphan edges into the next time window, because normal edges are already properly removed
 
         # Set nodes as unselected
         DB_handler.change_values(indices=self.nodes, field=NodeDB.selected, values=0)

--- a/trackedit/widgets/annotation/annotation_widget.py
+++ b/trackedit/widgets/annotation/annotation_widget.py
@@ -4,7 +4,7 @@ from qtpy.QtWidgets import QVBoxLayout, QWidget
 
 from motile_tracker.data_views import TracksViewer
 from trackedit.DatabaseHandler import DatabaseHandler
-from trackedit.widgets.annotation.todo_box import ToAnnotateBox
+from trackedit.widgets.annotation.toannotate_box import ToAnnotateBox
 
 
 class AnnotationWidget(QWidget):
@@ -18,17 +18,18 @@ class AnnotationWidget(QWidget):
         self.viewer = viewer
         self.databasehandler = databasehandler
         self.tracks_viewer = TracksViewer.get_instance(self.viewer)
-        self.current_todoannotation_index = 0
 
         # Create boxes
-        self.todo_box = ToAnnotateBox(self.tracks_viewer, self.databasehandler)
+        self.toannotate_box = ToAnnotateBox(self.tracks_viewer, self.databasehandler)
 
         # Forward signals
-        self.todo_box.refresh_annotation_layer.connect(self.refresh_annotation_layer)
+        self.toannotate_box.refresh_annotation_layer.connect(
+            self.refresh_annotation_layer
+        )
 
         # Layout
         main_layout = QVBoxLayout()
-        main_layout.addWidget(self.todo_box)
+        main_layout.addWidget(self.toannotate_box)
         main_layout.setSpacing(0)
         main_layout.setContentsMargins(10, 2, 10, 2)
         self.setLayout(main_layout)

--- a/trackedit/widgets/annotation/toannotate_box.py
+++ b/trackedit/widgets/annotation/toannotate_box.py
@@ -135,7 +135,7 @@ class ToAnnotateBox(NavigationBox):
     def annotate_track(self, label_str: str):
         label_int = self.get_label_int(label_str)
 
-        track_id = self.databasehandler.df.loc[self.current_selected_cell]["track_id"]
+        track_id = self.databasehandler.df_full.loc[self.current_selected_cell]["track_id"]
 
         self.databasehandler.annotate_track(
             track_id, label_int
@@ -203,14 +203,12 @@ class ToAnnotateBox(NavigationBox):
 
         selected_node = selected_nodes[0]
         self.current_selected_cell = selected_node
-        df = self.databasehandler.db_to_df(entire_database=True)
-        # ToDo, make full df a property of the databasehandler
 
-        label_int = self._update_label(df, selected_node)
+        label_int = self._update_label(selected_node)
 
         # update counter and buttons
         try:
-            track_id = df.loc[self.current_selected_cell]["track_id"]
+            track_id = self.databasehandler.df_full.loc[self.current_selected_cell]["track_id"]
             index = self.databasehandler.toannotate.index[
                 self.databasehandler.toannotate["track_id"] == track_id
             ][0]
@@ -224,13 +222,13 @@ class ToAnnotateBox(NavigationBox):
             # Track not found in annotations - disable counter and buttons
             self.toggle_buttons(False, label_int)
 
-    def _update_label(self, df, selected_node) -> int:
+    def _update_label(self, selected_node) -> int:
         """
         This function is called when the user clicks on a cell in the tree widget.
         It: - updates the label with the selected cell information
         """
         # update label
-        cell_info = df[df["id"] == selected_node].iloc[0]
+        cell_info = self.databasehandler.df_full[self.databasehandler.df_full["id"] == selected_node].iloc[0]
         generic_value = cell_info["generic"]  # type(generic_value) = int
         label = self.databasehandler.label_mapping(generic_value)  # type(label) = str
         self.selected_cell_label.setText(f"Selected cell: {selected_node} ({label})")


### PR DESCRIPTION
When a node is deleted that is connected to nodes in the next time window, we also need to delete the edge into that window. Otherwise the first node in the next window has a parent that does not exist anymore. 

Previously this was a problem, because databasehandler.df only contains the df of only that window, so no information was available about daughter cells in the next window. In this PR, `df_full` is made an attribute of `databasehandler`, and it is updated every time the `db` is changed (after a batch of changes). 