### PR TITLE
added tmax to solution_dataframe_from_sql

### DIFF
--- a/trackedit/DatabaseHandler.py
+++ b/trackedit/DatabaseHandler.py
@@ -19,12 +19,14 @@ from ultrack.core.database import (
     set_node_values,
 )
 from ultrack.core.export import tracks_layer_to_networkx, tracks_to_zarr
-from ultrack.core.export.utils import solution_dataframe_from_sql
 from ultrack.tracks.graph import add_track_ids_to_tracks_df
 
 from trackedit.arrays.DatabaseArray import DatabaseArray
 from trackedit.arrays.ImagingArray import SimpleImageArray
-from trackedit.utils.utils import annotations_to_zarr
+from trackedit.utils.utils import (
+    annotations_to_zarr,
+    solution_dataframe_from_sql_with_tmax,
+)
 
 NodeDB.generic = Column(Integer, default=-1)
 
@@ -477,8 +479,9 @@ class DatabaseHandler:
             Dataframe with columns: track_id, t, z, y, x
         """
 
-        df = solution_dataframe_from_sql(
+        df = solution_dataframe_from_sql_with_tmax(
             self.db_path_new,
+            tmax=self.Tmax,
             columns=(
                 NodeDB.id,
                 NodeDB.parent_id,


### PR DESCRIPTION
**Problem**
When using `tmax` to run TrackEdit, only the cells present in the first `tmax` frames are loaded, even though the database contains more timepoints. This creates a problem when the user deletes a cell in the last loaded frame (`tmax`). The problem is the next time the database is loaded, `add_track_ids_to_tracks_df` errors, because a cell in frame `tmax=1` doesn't have a parent, because that cell was deleted. Because `solution_dataframe_from_sql / add_track_ids_to_tracks_df` load all frames, and the `tmax` filtering happens afterwards. 

**Solution**
Instead of using `solution_dataframe_from_sql` from Ultrack, I added a duplicate version to `TrackEdit/utils` with an extra filter on `tmax`