### PR TITLE
add timestamp to every entry in the log file

### DIFF
--- a/trackedit/DatabaseHandler.py
+++ b/trackedit/DatabaseHandler.py
@@ -196,7 +196,8 @@ class DatabaseHandler:
     def log(self, message):
         """Append a message to the log file."""
         with open(self.log_file, "a") as log:
-            log.write(message + "\n")
+            time_stap = f"[{datetime.now()}]"
+            log.write(time_stap + " " + message + "\n")
 
     def initialize_config(self):
         # import db filename properly into an Ultrack config, neccesary for chaning values in database


### PR DESCRIPTION
New output: 

```console
[2025-05-20 16:11:18.573922] Start annotation session (2025-05-20 16:11:18.573717)
[2025-05-20 16:11:51.739355] db: setting parent_id[id=25000026] = -1 (was 24000028)
[2025-05-20 16:11:51.739508] db: setting parent_id[id=26000012] = -1 (was 25000026)
[2025-05-20 16:11:51.834972] db: setting generic[id=25000026] = -1 (was 2)
[2025-05-20 16:11:51.929467] db: setting selected[id=25000026] = 0 (was True)
[2025-05-20 16:11:52.131920] db: setting generic[id=2000006] = -1 (was 2)
[2025-05-20 16:11:52.132060] db: setting generic[id=3000007] = -1 (was 2)
```