### PR TITLE
Fix non-existing parent_ids in database

### DIFF
--- a/scripts/script_neuromast.py
+++ b/scripts/script_neuromast.py
@@ -13,14 +13,13 @@ warnings.filterwarnings("ignore", category=FutureWarning, message=".*qt_viewer.*
 
 # **********INPUTS*********
 # path to the working directory that contains the database file AND metadata.toml:
-# working_directory = Path(
-#     "/hpc/projects/group.royer/people/teun.huijben/data/Akila/trackedit_example_data/"
-# )
-working_directory = Path("/hpc/projects/tlg2/trackedit/corrupted_database/teun/")
+working_directory = Path(
+    "/hpc/projects/group.royer/people/teun.huijben/data/Akila/trackedit_example_data/"
+)
 # name of the database file to start from, or "latest" to start from the latest version, defaults to "data.db"
-db_filename_start = "data_v36_corrupted.db"
+db_filename_start = "latest"
 # maximum number of frames display, defaults to None (use all frames)
-tmax = 650
+tmax = 600
 # (Z),Y,X, defaults to (1, 1, 1)
 scale = (2.31, 1, 1)
 # overwrite existing database/changelog, defaults to False (not used when db_filename_start is "latest")

--- a/scripts/script_neuromast.py
+++ b/scripts/script_neuromast.py
@@ -13,13 +13,14 @@ warnings.filterwarnings("ignore", category=FutureWarning, message=".*qt_viewer.*
 
 # **********INPUTS*********
 # path to the working directory that contains the database file AND metadata.toml:
-working_directory = Path(
-    "/hpc/projects/group.royer/people/teun.huijben/data/Akila/trackedit_example_data/"
-)
+# working_directory = Path(
+#     "/hpc/projects/group.royer/people/teun.huijben/data/Akila/trackedit_example_data/"
+# )
+working_directory = Path("/hpc/projects/tlg2/trackedit/corrupted_database/teun/")
 # name of the database file to start from, or "latest" to start from the latest version, defaults to "data.db"
-db_filename_start = "latest"
+db_filename_start = "data_v36_corrupted.db"
 # maximum number of frames display, defaults to None (use all frames)
-tmax = 600
+tmax = 650
 # (Z),Y,X, defaults to (1, 1, 1)
 scale = (2.31, 1, 1)
 # overwrite existing database/changelog, defaults to False (not used when db_filename_start is "latest")

--- a/trackedit/DatabaseHandler.py
+++ b/trackedit/DatabaseHandler.py
@@ -25,6 +25,7 @@ from trackedit.arrays.DatabaseArray import DatabaseArray
 from trackedit.arrays.ImagingArray import SimpleImageArray
 from trackedit.utils.utils import (
     annotations_to_zarr,
+    remove_nonexisting_parents,
     solution_dataframe_from_sql_with_tmax,
 )
 
@@ -153,6 +154,10 @@ class DatabaseHandler:
         self.divisions = self.find_all_divisions()
         self.red_flags_ignore_list = []
         self.log(f"Start annotation session ({datetime.now()})")
+        self.log(
+            f"Parameters: Tmax: {self.Tmax}, working_directory: {self.working_directory}, "
+            f"db_filename: {self.db_filename_new}"
+        )
 
         # Default label for unlabeled cells
         default_annotation = {
@@ -531,6 +536,7 @@ class DatabaseHandler:
                 NodeDB.generic,
             ),
         )
+        df = remove_nonexisting_parents(df)
         df = add_track_ids_to_tracks_df(df)
         df.sort_values(by=["track_id", "t"], inplace=True)
 

--- a/trackedit/utils/utils.py
+++ b/trackedit/utils/utils.py
@@ -288,7 +288,7 @@ def remove_nonexisting_parents(df: pd.DataFrame) -> pd.DataFrame:
     """
     Remove parents that do not exist in the dataframe.
     Why:
-    Let's say we have a database with 200 frames, with tracks spanning all 200 farmes.
+    Let's say we have a database with 200 frames, with tracks spanning all 200 frames.
     But if the database is opened with tMax=100, and a cell i is deleted at t=100,
     the parent_id of its parent cell (at t=101) in the database is still i.
     If later, the database is opened with tMax=200, the parent_id of the cell at t=101 is still i,


### PR DESCRIPTION
added check to df if parent_ids refer to cells that have been removed in an earlier session, necessary to assign track ids

**problem:**    
Let's say we have a database with 200 frames, with tracks spanning all 200 frames.
But if the database is opened with tMax=100, and a cell i is deleted at t=100,
the parent_id of its parent cell (at t=101) in the database is still i.
If later, the database is opened with tMax=200, the parent_id of the cell at t=101 is still i,
but cell i no longer exist, giving an error when assigning track_ids.